### PR TITLE
Add security headers via vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,33 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://r.jina.ai; frame-src https://calendar.google.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), payment=()"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION

Added a `vercel.json` that sets security response headers on all routes:

- **Content-Security-Policy** - restricts the page to its own origin, plus any external resources the site uses: Google Fonts (`fonts.googleapis.com` / `fonts.gstatic.com`), the Google Calendar embed on the Events page (`frame-src calendar.google.com`), and the Gallery title fetch (`connect-src r.jina.ai`). Scripts are limited to `'self'` with no `unsafe-inline`/`unsafe-eval`; `style-src 'unsafe-inline'` is required because React, GSAP, and Framer Motion set inline style attributes
- **frame-ancestors 'none'** + **X-Frame-Options: DENY** - clickjacking protection
- **X-Content-Type-Options: nosniff**
- **Referrer-Policy: strict-origin-when-cross-origin**
- **Strict-Transport-Security**- 2-year HSTS
- **Permissions-Policy** - disables camera, microphone, geolocation, and payment APIs

The site currently has no security headers, so the CSP is defense-in-depth against XSS and the rest are standard best practices for a static site

## Reviewer notes

- Headers can't be tested locally, on the preview deployment, check the Events page (calendar iframe) and Gallery page (title fetch), any CSP violation will show in the browser console
- Any future external resource (analytics, image CDN, new embed) will need its domain added to the matching CSP directive